### PR TITLE
Meta tag description not working

### DIFF
--- a/src/Torann/LaravelMetaTags/MetaTag.php
+++ b/src/Torann/LaravelMetaTags/MetaTag.php
@@ -127,7 +127,7 @@ class MetaTag
     {
         return $this->createTag([
             'name' => $key,
-            'content' => $value
+            'content' => $value?:$this->metas[$key]
         ]);
     }
 

--- a/src/Torann/LaravelMetaTags/MetaTag.php
+++ b/src/Torann/LaravelMetaTags/MetaTag.php
@@ -3,6 +3,7 @@
 namespace Torann\LaravelMetaTags;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 
 class MetaTag
 {
@@ -127,7 +128,7 @@ class MetaTag
     {
         return $this->createTag([
             'name' => $key,
-            'content' => $value?:$this->metas[$key]
+            'content' => $value ?: Arr::get($this->metas, $key, '')
         ]);
     }
 


### PR DESCRIPTION
Default value was not working. I set description from controller and that worked for og:description, but the meta tag description content was empty for {!! Meta::tag('description'); !!}.
