### PR TITLE
Added fbAppId method

### DIFF
--- a/src/Torann/LaravelMetaTags/MetaTag.php
+++ b/src/Torann/LaravelMetaTags/MetaTag.php
@@ -191,6 +191,19 @@ class MetaTag
     }
 
     /**
+     * Create Facebook app ID tag
+     *
+     * @return string
+     */
+    public function fbAppId()
+    {
+        return $this->createTag([
+            'property' => 'fb:app_id',
+            'content' => $this->get('fb:app_id'),
+        ]);
+    }
+
+    /**
      * Create twitter card tags
      *
      * @return string


### PR DESCRIPTION
The `fb:app_id` tag uses `property` instead of `name`, this adds a dedicated method to correctly display this tag.