### PR TITLE
Use both property and name keys

### DIFF
--- a/src/Torann/LaravelMetaTags/MetaTag.php
+++ b/src/Torann/LaravelMetaTags/MetaTag.php
@@ -128,6 +128,7 @@ class MetaTag
     {
         return $this->createTag([
             'name' => $key,
+            'property' => $key,
             'content' => $value ?: Arr::get($this->metas, $key, ''),
         ]);
     }


### PR DESCRIPTION
e.g. Facebook looks for 'property' in MetaTags instead of 'name'